### PR TITLE
Abstract Base Package Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Teleport 1.2.1 (TBD)
+
+  * Switch order of posix user and group switching attempts
+
 ### Teleport 1.2.0 (2015-08-09)
 
   * Add ability to include package attributes in an Extract tpl


### PR DESCRIPTION
Allows for custom names in extended implementations. If it becomes desirable to include naming logic in the library, this will additionally make it easier to do so. The purpose behind this change is to allow for extensions of different types to choose a different naming scheme based on a development/release path. For instance, for an extra, the site profile is not nearly as important as it is for a site backup or transfer.

Sample Extension:
```
class ExtractExtra extends Teleport\Action\Extract {
    protected function getName() {
    // No profile prefix
        return $this->tpl['name'];
    }
}
```