### PR TITLE
Skip bad custom data tables

### DIFF
--- a/src/Teleport/Action/Extract.php
+++ b/src/Teleport/Action/Extract.php
@@ -368,6 +368,10 @@ class Extract extends Action
                             /* collect the rows and generate INSERT statements */
                             $object['data'] = array();
                             $stmt = $this->modx->query("SELECT * FROM {$this->modx->escape($extraTable)}");
+                            if (!$stmt) {
+                                $this->request->log("Skipping table {$extraTable} as SELECT query failed");
+                                break;
+                            }
                             while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
                                 if ($instances === 0) {
                                     $fields = implode(', ', array_map(array($this->modx, 'escape'), array_keys($row)));


### PR DESCRIPTION
In some cases, a database view can appear in the query for table names. If such a view is "bad"
i.e. it contains errors, then the query for the table's data during Extract will fail.

This commit adds a check to bypass the table if the query failed.