### PR TITLE
replace each() with foreach() for PHP 8 compatibility

### DIFF
--- a/src/Teleport/Action/Extract.php
+++ b/src/Teleport/Action/Extract.php
@@ -389,7 +389,7 @@ class Extract extends Action
                                     $fields = implode(', ', array_map(array($this->modx, 'escape'), array_keys($row)));
                                 }
                                 $values = array();
-                                while (list($key, $value) = each($row)) {
+                                foreach ($row as $key => $value) {
                                     switch (gettype($value)) {
                                         case 'string':
                                             $values[] = $this->modx->quote($value);
@@ -450,4 +450,4 @@ class Extract extends Action
         }
         return $vehicleCount;
     }
-} 
+}


### PR DESCRIPTION
Why needed? Fatal error in PHP 8.0.