### PR TITLE
Fix destination of FileVehicle files

### DIFF
--- a/src/Teleport/Transport/FileVehicle.php
+++ b/src/Teleport/Transport/FileVehicle.php
@@ -81,9 +81,9 @@ class FileVehicle extends xPDOFileVehicle {
             $rootFolder = explode('/', $this->payload['object']['in']);
             $rootFolder = array_pop($rootFolder);
             $this->payload['object']['name'] = $rootFolder;
-            $this->payload['object']['source'] = $transport->signature . '/' . strtr($this->payload['class'], '\\', '/') . '/' . $this->payload['signature'];
+            $this->payload['object']['source'] = $transport->signature . '/' . str_replace('\\', '/', $this->payload['class']) . '/' . $this->payload['signature'];
 
-            $filePath = $transport->path . $transport->signature . '/' . strtr($this->payload['class'], '\\', '/') . '/' . $this->payload['signature'] . '/' . $rootFolder;
+            $filePath = $transport->path . $transport->signature . '/' . str_replace('\\', '/', $this->payload['class']) . '/' . $this->payload['signature'] . '/' . $rootFolder;
 
             $fs->mkdir($filePath);
 

--- a/src/Teleport/Transport/FileVehicle.php
+++ b/src/Teleport/Transport/FileVehicle.php
@@ -81,9 +81,9 @@ class FileVehicle extends xPDOFileVehicle {
             $rootFolder = explode('/', $this->payload['object']['in']);
             $rootFolder = array_pop($rootFolder);
             $this->payload['object']['name'] = $rootFolder;
-            $this->payload['object']['source'] = $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'];
+            $this->payload['object']['source'] = $transport->signature . '/' . strtr($this->payload['class'], '\\', '/') . '/' . $this->payload['signature'];
 
-            $filePath = $transport->path . $transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature'] . '/' . $rootFolder;
+            $filePath = $transport->path . $transport->signature . '/' . strtr($this->payload['class'], '\\', '/') . '/' . $this->payload['signature'] . '/' . $rootFolder;
 
             $fs->mkdir($filePath);
 


### PR DESCRIPTION
Right now files are getting stored to: `$transport->signature . '/' . $this->payload['class'] . '/' . $this->payload['signature']` which translates to path like: `.../Teleport\Transport\FileVehicle/83e9...`.

But when installing the vehicle, it's trying to copy files from `.../Teleport/Transport/FileVehicle/83e9...`.

FileVehicle uses custom `_compilePayload` and was missing `str_replace('\\', '/', $this->payload['class'])`